### PR TITLE
Add dockerfile and example compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,12 +72,8 @@ If you don't want to install unneeded software directly onto your system, it is 
 
 ### Docker support
 
-Currently, there are no pre-built docker images for DAS, because I have not used docker in years.
-If you want to run DAS in docker, I recommend basing it off a Debian 11 image.
-You will need to export the ports for LDAP and proxy authentication if you wish to use those features.
-
-If you are a fervent docker user and would like to contribute, a pre-made docker image would be much appreciated.
-If you feel so inclined, please submit a pull request where you update this section of the README to refer to your docker image, so I can qualify it and make it official.
+A `Dockerfile` is provided in the `docker` directory of this repo, along with an example `docker-compose.yml`. It uses environment variables as specified in `config/runtime.exs.docker`
+so it is easiest to look at that to see what is supported.
 
 ## Usage
 

--- a/config/runtime.exs.docker
+++ b/config/runtime.exs.docker
@@ -17,9 +17,9 @@ session_timeout: 8*60,
 
 #LDAP settings
 #The IP and port for the LDAP server to listen on. Mind the syntax for the IP
-#Default to 127.0.0.1:389
+#Default to 127.0.0.1:3389
 ldap_ip: System.get_env("DAS_LDAP_HOST", "127.0.0.1") |> String.split(".") |> Enum.map(&String.to_integer/1) |> List.to_tuple(),
-ldap_port: System.get_env("DAS_LDAP_PORT", "389") |> String.to_integer(),
+ldap_port: System.get_env("DAS_LDAP_PORT", "3389") |> String.to_integer(),
 #Alternatively, uncomment these lines (and comment the above) to listen for LDAP on a socket
 #ldap_ip: {:local, "/var/run/das_ldap.sock"}
 #ldap_port: 0

--- a/config/runtime.exs.docker
+++ b/config/runtime.exs.docker
@@ -1,0 +1,63 @@
+import Config
+
+#Global settings
+config :das,
+#which type of database to use; optoins are :sqlite, :mysql, or :postgres
+db_type: System.get_env("DAS_DB_TYPE", "sqlite") |> String.to_existing_atom(),
+#Which ip and port to listen on for web requests. Mind the syntax for the ip bind.
+#Defaults to 127.0.0.0:8080.
+bind_ip: System.get_env("DAS_WEB_HOST", "127.0.0.1") |> String.split(".") |> Enum.map(&String.to_integer/1) |> List.to_tuple(),
+bind_port: System.get_env("DAS_WEB_PORT", "8080") |> String.to_integer(),
+#Alternatively, uncomment these lines (and comment the above) to listen on a socket
+#bind_ip: {:local, "/var/run/das.sock"}
+#bind_port: 0
+
+#How long a session lasts, in minutes. Default: 8*60
+session_timeout: 8*60,
+
+#LDAP settings
+#The IP and port for the LDAP server to listen on. Mind the syntax for the IP
+#Default to 127.0.0.1:389
+ldap_ip: System.get_env("DAS_LDAP_HOST", "127.0.0.1") |> String.split(".") |> Enum.map(&String.to_integer/1) |> List.to_tuple(),
+ldap_port: System.get_env("DAS_LDAP_PORT", "389") |> String.to_integer(),
+#Alternatively, uncomment these lines (and comment the above) to listen for LDAP on a socket
+#ldap_ip: {:local, "/var/run/das_ldap.sock"}
+#ldap_port: 0
+#The two lines under here define where in the presented LDAP directory structure the users and clients will appear to be
+#Altering these settings will have no effect on the functionality of the software, and its advised to leave them alone if you don't know what they represent.
+#The value of these is mostly irrelevant, as DAS will interpret any values as referring to the users table; however, client applications may expect them to be valid LDAP DN components.
+ldap_clients_area: System.get_env("DAS_LDAP_CLIENTS", "ou=clients,dc=das,dc=nl"),
+ldap_users_area: System.get_env("DAS_LDAP_USERS", "ou=users,dc=das,dc=nl"),
+#The port to listen to for forward authentication
+#Defaults to 8081
+forward_port: System.get_env("DAS_FWD_PORT", "8081") |> Integer.parse(),
+
+#Enable the Utility socket? Defaults to false
+util_socket: false,
+#The location of the utility socket. Defaults to "/tmp/das_util"
+util_socket_location: "/tmp/das_util.sock",
+#The file permissions on the utility socket. Defaults to 200.
+util_socket_permissions: 200,
+
+#If DAS detects an empty user database, should it add a default user? (defaults to false).
+#For security reasons, it is recommended to disable this setting after initial setup of the software.
+default_add: System.get_env("DAS_INIT_SETUP", "false") in ["true", "TRUE", "True"],
+#username, email, and password of this user: 
+default_username: System.get_env("DAS_INIT_USER", "admin"),
+default_email: System.get_env("DAS_INIT_EMAIL", "admin@example.com"),
+default_password: System.get_env("DAS_INIT_PASS", "badgers")
+
+
+#Settings for Postgres or MySQL; uncomment the one which applies
+#config :das, Storage.Postgres
+#config :das, Storage.MySQL,
+#hostname: "localhost",
+#username: "das",
+#database: "das",
+#password: "password"
+
+config :das, Map.get(%{"sqlite" => Storage.SQLite, "mysql" => Storage.MySQL, "postgres" => Storage.Postgres}, System.get_env("DAS_DB_TYPE", "sqlite"), "Invalid DB Type"),
+database: System.get_env("DAS_DB_NAME", "das"),
+username: System.get_env("DAS_DB_USER", "das"),
+password: System.get_env("DAS_DB_PASS", "badgers"),
+hostname: System.get_env("DAS_DB_HOST", "localhost")

--- a/config/runtime.exs.docker
+++ b/config/runtime.exs.docker
@@ -6,7 +6,7 @@ config :das,
 db_type: System.get_env("DAS_DB_TYPE", "sqlite") |> String.to_existing_atom(),
 #Which ip and port to listen on for web requests. Mind the syntax for the ip bind.
 #Defaults to 127.0.0.0:8080.
-bind_ip: System.get_env("DAS_WEB_HOST", "127.0.0.1") |> String.split(".") |> Enum.map(&String.to_integer/1) |> List.to_tuple(),
+bind_ip: System.get_env("DAS_WEB_HOST", "0.0.0.0") |> String.split(".") |> Enum.map(&String.to_integer/1) |> List.to_tuple(),
 bind_port: System.get_env("DAS_WEB_PORT", "8080") |> String.to_integer(),
 #Alternatively, uncomment these lines (and comment the above) to listen on a socket
 #bind_ip: {:local, "/var/run/das.sock"}
@@ -18,7 +18,7 @@ session_timeout: 8*60,
 #LDAP settings
 #The IP and port for the LDAP server to listen on. Mind the syntax for the IP
 #Default to 127.0.0.1:3389
-ldap_ip: System.get_env("DAS_LDAP_HOST", "127.0.0.1") |> String.split(".") |> Enum.map(&String.to_integer/1) |> List.to_tuple(),
+ldap_ip: System.get_env("DAS_LDAP_HOST", "0.0.0.0") |> String.split(".") |> Enum.map(&String.to_integer/1) |> List.to_tuple(),
 ldap_port: System.get_env("DAS_LDAP_PORT", "3389") |> String.to_integer(),
 #Alternatively, uncomment these lines (and comment the above) to listen for LDAP on a socket
 #ldap_ip: {:local, "/var/run/das_ldap.sock"}

--- a/config/runtime.exs.example
+++ b/config/runtime.exs.example
@@ -17,7 +17,7 @@ session_timeout: 8*60,
 
 #LDAP settings
 #The IP and port for the LDAP server to listen on. Mind the syntax for the IP
-#Default to 127.0.0.1:389
+#Default to 127.0.0.1:3389
 ldap_ip: {127, 0, 0, 1},
 ldap_port: 3389,
 #Alternatively, uncomment these lines (and comment the above) to listen for LDAP on a socket

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,41 @@
+FROM debian:11
+
+ENV DEPLOY_USER das
+ENV DEPLOY_USER_DIR /home/${DEPLOY_USER}
+
+RUN useradd ${DEPLOY_USER} --create-home --shell /bin/bash
+
+# install dependencies
+RUN apt-get update && \
+    apt-get -y install --no-install-recommends \
+        bash locales \
+	libssl1.1 \
+        && \
+    apt-get clean && \
+    find /var/lib/apt/lists -type f -delete
+
+RUN echo "${DEPLOY_USER} ALL=NOPASSWD: ALL" >> /etc/sudoers
+
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    echo 'LANG="en_US.UTF-8"'>/etc/default/locale && \
+    dpkg-reconfigure --frontend=noninteractive locales && \
+    update-locale LANG=en_US.UTF-8
+
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+ENV LANG C.UTF-8
+
+ADD https://github.com/florisbreggeman/das/releases/download/1.0.0/das-1.0.0.tar.gz ${DEPLOY_USER_DIR}/das.tar.gz
+
+RUN chown ${DEPLOY_USER}:${DEPLOY_USER} -R ${DEPLOY_USER_DIR}
+
+USER ${DEPLOY_USER}
+
+WORKDIR ${DEPLOY_USER_DIR}
+
+RUN tar -vxf ${DEPLOY_USER_DIR}/das.tar.gz -C ${DEPLOY_USER_DIR}
+
+RUN cp /home/das/das/releases/1.0/runtime.exs.docker /home/das/das/releases/1.0/runtime.exs
+
+CMD ["/home/das/das/bin/das", "start"]]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '2.1'
+services:
+  das:
+    restart: on-failure:5
+    build:
+      context: '.'
+      dockerfile: 'Dockerfile'
+    ports:
+      - 8080:8080
+      - 8081:8081
+      - 3389:3389
+    environment:
+      - DAS_DB_TYPE=mysql
+      - DAS_WEB_HOST=0.0.0.0
+      - DAS_LDAP_HOST=0.0.0.0
+      - DAS_INIT_SETUP=true
+      - DAS_DB_HOST=database
+      - DAS_DB_PASS="pass"


### PR DESCRIPTION
Doesn't compile on Ububu so I decided to make a dockerfile.

Because your configuration does not accept environment variables, the only way to properly configure DAS when using Docker is through mounting a folder with the config file in it. An example of this is shown in the attached `docker-compose`.