### PR TITLE
Fix `Basic` header authorization

### DIFF
--- a/lib/oauth/router.ex
+++ b/lib/oauth/router.ex
@@ -76,7 +76,7 @@ defmodule OAuth.Router do
     #verify the client first
     client_id = Map.get(body, "client_id")
     secret = Map.get(body, "client_secret")
-    secret = if secret == nil do Map.get(headers, "authorization", "") |> String.split() |> Enum.at(1) else secret end #allow for authorization via HTTP headers if not provided in body
+    secret = if secret == nil do Map.get(headers, "authorization", "") |> String.split() |> Enum.at(1) |> Base.decode64!() else secret end #allow for authorization via HTTP headers if not provided in body
     if Clients.verify(client_id, secret) == nil do
       conn
       |> put_resp_content_type("text/plain")

--- a/lib/oauth/router.ex
+++ b/lib/oauth/router.ex
@@ -76,7 +76,9 @@ defmodule OAuth.Router do
     #verify the client first
     client_id = Map.get(body, "client_id")
     secret = Map.get(body, "client_secret")
-    secret = if secret == nil do Map.get(headers, "authorization", "") |> String.split() |> Enum.at(1) |> Base.decode64!() else secret end #allow for authorization via HTTP headers if not provided in body
+    if secret == nil or client_id == nil do #allow for authorization via HTTP headers if not provided in body
+      [client_id, secret] = Map.get(headers, "authorization", "") |> String.split() |> Enum.at(1) |> Base.decode64!() |> String.split(":")
+    done
     if Clients.verify(client_id, secret) == nil do
       conn
       |> put_resp_content_type("text/plain")


### PR DESCRIPTION
As discussed here: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization#basic_authentication the client+secret encoded in an `Authorization: Basic` header are base64 decoded, however, DAS never decodes this and thus will say that the secret is incorrect. This simple commit fixes it.